### PR TITLE
chore: standardized EventSignal names

### DIFF
--- a/packages/core/src/entity/entity.ts
+++ b/packages/core/src/entity/entity.ts
@@ -30,9 +30,9 @@ import { ItemBundleTrait, ItemStack } from "../item";
 import { CommandExecutionState } from "../commands";
 import {
   EntityDespawnedSignal,
-  EntityDieEventSignal,
+  EntityDieSignal,
   EntityDimensionChangeSignal,
-  EntityHitEventSignal,
+  EntityHitSignal,
   EntitySpawnedSignal,
   PlayerInteractWithEntitySignal
 } from "../events";
@@ -525,7 +525,7 @@ class Entity {
    * Kills the entity.
    */
   public kill(damagingEntity?: Entity, damageCause?: ActorDamageCause): void {
-    new EntityDieEventSignal(this, damagingEntity, damageCause).emit();
+    new EntityDieSignal(this, damagingEntity, damageCause).emit();
 
     // Set the entity as not alive
     this.isAlive = false;
@@ -585,7 +585,7 @@ class Entity {
       );
       if (!signal.emit()) return;
     } else {
-      const signal = new EntityHitEventSignal(player, this);
+      const signal = new EntityHitSignal(player, this);
 
       if (!signal.emit()) return;
     }

--- a/packages/core/src/entity/traits/attribute/health.ts
+++ b/packages/core/src/entity/traits/attribute/health.ts
@@ -10,10 +10,7 @@ import {
 
 import { EntityIdentifier, EntityInteractMethod } from "../../../enums";
 import { Player } from "../../player";
-import {
-  EntityHealthChangedEventSignal,
-  EntityHurtEventSignal
-} from "../../../events";
+import { EntityHealthChangedSignal, EntityHurtSignal } from "../../../events";
 import { Entity } from "../../entity";
 
 import { EntityAttributeTrait } from "./attribute";
@@ -32,7 +29,7 @@ class EntityHealthTrait extends EntityAttributeTrait {
     damager?: Entity,
     cause?: ActorDamageCause
   ): void {
-    const signal = new EntityHurtEventSignal(
+    const signal = new EntityHurtSignal(
       this.entity,
       amount,
       cause,
@@ -58,7 +55,7 @@ class EntityHealthTrait extends EntityAttributeTrait {
   }
 
   public set(value: number): void {
-    const signal = new EntityHealthChangedEventSignal(
+    const signal = new EntityHealthChangedSignal(
       this.entity,
       this.currentValue,
       value

--- a/packages/core/src/entity/traits/effects.ts
+++ b/packages/core/src/entity/traits/effects.ts
@@ -10,7 +10,7 @@ import {
 import { Effect } from "../../effect";
 import { EntityIdentifier } from "../../enums";
 import { EntityEffectOptions } from "../../types";
-import { EffectAddEventSignal, EffectRemoveEventSignal } from "../../events";
+import { EffectAddSignal, EffectRemoveSignal } from "../../events";
 
 import { EntityTrait } from "./trait";
 
@@ -57,7 +57,7 @@ class EntityEffectsTrait extends EntityTrait {
 
   public remove(effectType: EffectType): void {
     if (!this.effects.has(effectType)) return;
-    const signal = new EffectRemoveEventSignal(this.entity, effectType);
+    const signal = new EffectRemoveSignal(this.entity, effectType);
 
     signal.emit();
     this.effects.get(effectType)?.onRemove?.(this.entity);
@@ -120,7 +120,7 @@ class EntityEffectsTrait extends EntityTrait {
     }
     // eslint fix
     if (!effect) return;
-    const signal = new EffectAddEventSignal(this.entity, effect);
+    const signal = new EffectAddSignal(this.entity, effect);
 
     if (!signal.emit()) return;
 

--- a/packages/core/src/events/effect-add.ts
+++ b/packages/core/src/events/effect-add.ts
@@ -4,7 +4,7 @@ import { WorldEvent } from "../enums";
 
 import { EventSignal } from "./event-signal";
 
-class EffectAddEventSignal extends EventSignal {
+class EffectAddSignal extends EventSignal {
   public static readonly identifier: WorldEvent = WorldEvent.EffectAdd;
 
   /**
@@ -24,4 +24,4 @@ class EffectAddEventSignal extends EventSignal {
   }
 }
 
-export { EffectAddEventSignal };
+export { EffectAddSignal };

--- a/packages/core/src/events/effect-remove.ts
+++ b/packages/core/src/events/effect-remove.ts
@@ -5,7 +5,7 @@ import { WorldEvent } from "../enums";
 
 import { EventSignal } from "./event-signal";
 
-class EffectRemoveEventSignal extends EventSignal {
+class EffectRemoveSignal extends EventSignal {
   public static readonly identifier: WorldEvent = WorldEvent.EffectRemove;
 
   /**
@@ -25,4 +25,4 @@ class EffectRemoveEventSignal extends EventSignal {
   }
 }
 
-export { EffectRemoveEventSignal };
+export { EffectRemoveSignal };

--- a/packages/core/src/events/effect-remove.ts
+++ b/packages/core/src/events/effect-remove.ts
@@ -6,7 +6,7 @@ import { WorldEvent } from "../enums";
 import { EventSignal } from "./event-signal";
 
 class EffectRemoveEventSignal extends EventSignal {
-  public static readonly identifier: WorldEvent = WorldEvent.EffectAdd;
+  public static readonly identifier: WorldEvent = WorldEvent.EffectRemove;
 
   /**
    * The entity where the effect was removed

--- a/packages/core/src/events/entity-die.ts
+++ b/packages/core/src/events/entity-die.ts
@@ -5,7 +5,7 @@ import { WorldEvent } from "../enums";
 
 import { EventSignal } from "./event-signal";
 
-class EntityDieEventSignal extends EventSignal {
+class EntityDieSignal extends EventSignal {
   public static readonly identifier: WorldEvent = WorldEvent.EntityDie;
 
   /**
@@ -35,4 +35,4 @@ class EntityDieEventSignal extends EventSignal {
   }
 }
 
-export { EntityDieEventSignal };
+export { EntityDieSignal };

--- a/packages/core/src/events/entity-health-changed.ts
+++ b/packages/core/src/events/entity-health-changed.ts
@@ -3,7 +3,7 @@ import { WorldEvent } from "../enums";
 
 import { EventSignal } from "./event-signal";
 
-class EntityHealthChangedEventSignal extends EventSignal {
+class EntityHealthChangedSignal extends EventSignal {
   public static readonly identifier: WorldEvent = WorldEvent.HealthChanged;
 
   /**
@@ -29,4 +29,4 @@ class EntityHealthChangedEventSignal extends EventSignal {
   }
 }
 
-export { EntityHealthChangedEventSignal };
+export { EntityHealthChangedSignal };

--- a/packages/core/src/events/entity-hit.ts
+++ b/packages/core/src/events/entity-hit.ts
@@ -3,7 +3,7 @@ import { WorldEvent } from "../enums";
 
 import { EventSignal } from "./event-signal";
 
-class EntityHitEventSignal extends EventSignal {
+class EntityHitSignal extends EventSignal {
   public static readonly identifier: WorldEvent = WorldEvent.EntityHit;
 
   /**
@@ -23,4 +23,4 @@ class EntityHitEventSignal extends EventSignal {
   }
 }
 
-export { EntityHitEventSignal };
+export { EntityHitSignal };

--- a/packages/core/src/events/entity-hurt.ts
+++ b/packages/core/src/events/entity-hurt.ts
@@ -5,7 +5,7 @@ import { WorldEvent } from "../enums";
 
 import { EventSignal } from "./event-signal";
 
-class EntityHurtEventSignal extends EventSignal {
+class EntityHurtSignal extends EventSignal {
   public static readonly identifier: WorldEvent = WorldEvent.EntityHurt;
 
   /**
@@ -42,4 +42,4 @@ class EntityHurtEventSignal extends EventSignal {
   }
 }
 
-export { EntityHurtEventSignal };
+export { EntityHurtSignal };

--- a/packages/core/src/types/world/events.ts
+++ b/packages/core/src/types/world/events.ts
@@ -1,17 +1,17 @@
 import { WorldEvent } from "../../enums";
 import {
   ChunkReadySignal,
-  EffectAddEventSignal,
-  EffectRemoveEventSignal,
+  EffectAddSignal,
+  EffectRemoveSignal,
   EntityAttributeUpdateSignal,
   EntityDespawnedSignal,
   EntityDimensionChangeSignal,
   EntityFlagUpdateSignal,
-  EntityHitEventSignal,
-  EntityHurtEventSignal,
+  EntityHitSignal,
+  EntityHurtSignal,
   EntityMetadataUpdateSignal,
   EntitySpawnedSignal,
-  EntityHealthChangedEventSignal,
+  EntityHealthChangedSignal,
   PlayerAbilityUpdateSignal,
   PlayerBreakBlockSignal,
   PlayerChatSignal,
@@ -29,7 +29,7 @@ import {
   PlayerUseItemSignal,
   WorldInitializeSignal,
   WorldTickSignal,
-  EntityDieEventSignal
+  EntityDieSignal
 } from "../../events";
 
 interface WorldEventSignals {
@@ -42,12 +42,12 @@ interface WorldEventSignals {
   [WorldEvent.EntityDimensionChange]: [EntityDimensionChangeSignal];
   [WorldEvent.EntityMetadataUpdate]: [EntityMetadataUpdateSignal];
   [WorldEvent.EntityAttributeUpdate]: [EntityAttributeUpdateSignal];
-  [WorldEvent.EntityHit]: [EntityHitEventSignal];
-  [WorldEvent.EntityDie]: [EntityDieEventSignal];
-  [WorldEvent.EntityHurt]: [EntityHurtEventSignal];
-  [WorldEvent.HealthChanged]: [EntityHealthChangedEventSignal];
-  [WorldEvent.EffectAdd]: [EffectAddEventSignal];
-  [WorldEvent.EffectRemove]: [EffectRemoveEventSignal];
+  [WorldEvent.EntityHit]: [EntityHitSignal];
+  [WorldEvent.EntityDie]: [EntityDieSignal];
+  [WorldEvent.EntityHurt]: [EntityHurtSignal];
+  [WorldEvent.HealthChanged]: [EntityHealthChangedSignal];
+  [WorldEvent.EffectAdd]: [EffectAddSignal];
+  [WorldEvent.EffectRemove]: [EffectRemoveSignal];
   [WorldEvent.PlayerJoin]: [PlayerJoinSignal];
   [WorldEvent.PlayerLeave]: [PlayerLeaveSignal];
   [WorldEvent.PlayerChat]: [PlayerChatSignal];


### PR DESCRIPTION
Replaced `XXEventSignal` to `XXSignal` and fixed the identifier of `EffectRemoveSignal`.