### PR TITLE
Plugin Priority System

### DIFF
--- a/packages/plugins/src/enums/priority.ts
+++ b/packages/plugins/src/enums/priority.ts
@@ -1,0 +1,31 @@
+/**
+ * The priority of a plugin determines when it will be loaded in relation to other plugins.
+ * A plugin with a higher priority will be loaded before a plugin with a lower priority.
+ * This is useful for plugins that need to be loaded before or after other plugins.
+ * For example, a library plugin may need to be loaded before a plugin that uses it,
+ * or a plugin that modifies the behavior of serenity's APIs may need to be loaded after it.
+ * The default priority is Normal.
+ */
+enum PluginPriority {
+
+  /**
+   * A low priority plugin will be loaded after other plugins.
+   * Useful for reacting to changes or final adjustments.
+   */
+  Low,
+
+  /**
+   * The default priority for a plugin.
+   * Suitable for standard plugin behavior.
+   */
+  Normal,
+
+  /**
+   * A high priority plugin will be loaded before other plugins.
+   * Useful for early setup or overriding behavior.
+   */
+  High
+}
+
+
+export { PluginPriority };

--- a/packages/plugins/src/plugin.ts
+++ b/packages/plugins/src/plugin.ts
@@ -10,6 +10,7 @@ import {
   PluginEntityRegistry,
   PluginItemRegistry
 } from "./registry";
+import { PluginPriority } from "./enums/priority";
 
 interface PluginOptions extends Partial<PluginEvents> {
   /**
@@ -21,6 +22,11 @@ interface PluginOptions extends Partial<PluginEvents> {
    * The type of the plugin.
    */
   type: PluginType;
+
+  /**
+   * The type of the plugin.
+   */
+  priority: PluginPriority;
 
   /**
    * The maximum number of listeners for the plugin.
@@ -79,6 +85,12 @@ class Plugin<T = unknown> extends Emitter<T> implements PluginOptions {
    * The type of the plugin.
    */
   public readonly type: PluginType;
+
+  /**
+   * The priority of the plugin.
+   * @note This is used to determine the order in which plugins are loaded.
+   */
+  public readonly priority: PluginPriority = PluginPriority.Normal;
 
   /**
    * The block registry for the plugin.


### PR DESCRIPTION
Adds a plugin priority system, allowing plugins to specify their execution order. Useful for library plugins and similar plugins that need to be initialized before others.