### PR TITLE
fix: allow `time set 0`

### DIFF
--- a/.changeset/strange-ears-stare.md
+++ b/.changeset/strange-ears-stare.md
@@ -1,0 +1,5 @@
+---
+"@serenityjs/core": patch
+---
+
+Fix the time set/add command to only allow positive integers (or 0)

--- a/packages/core/src/commands/operator/time.ts
+++ b/packages/core/src/commands/operator/time.ts
@@ -27,9 +27,9 @@ const register = (world: World) => {
           switch (operation) {
             case "set": {
               // Check if the value is not a number
-              if (!value)
+              if (typeof value !== "number" || Number.isNaN(value) || value < 0)
                 throw new Error(
-                  "Invalid value for time of day, expected a integer"
+                  "Invalid value for time of day, expected a positive integer"
                 );
 
               // Set the time of day
@@ -44,9 +44,9 @@ const register = (world: World) => {
 
             case "add": {
               // Check if the value is not a number
-              if (!value)
+              if (typeof value !== "number" || Number.isNaN(value) || value < 0)
                 throw new Error(
-                  "Invalid value for time of day, expected a integer"
+                  "Invalid value for time of day, expected a positive integer"
                 );
 
               // Add the time of day


### PR DESCRIPTION
Note: We should probably add tests for things like this in the future once the vitest PR is merged.