### PR TITLE
Fix incorrectly named property 'resourcePacks'

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -11,7 +11,7 @@ const serenity = new Serenity({
   path: "./properties.json",
   serenity: {
     permissions: "./permissions.json",
-    resourcePacks: "./resource_packs",
+    resources: "./resource_packs",
   }
 });
 

--- a/packages/core/src/types/resource/properties.ts
+++ b/packages/core/src/types/resource/properties.ts
@@ -6,7 +6,7 @@ interface ResourcePackEntry {
 interface ResourcePacksProperties {
   path: string | null;
   mustAcceptPacks: boolean;
-  resourcePacks: Array<ResourcePackEntry>;
+  resources: Array<ResourcePackEntry>;
 }
 
 export { ResourcePackEntry, ResourcePacksProperties };


### PR DESCRIPTION
Rename 'resourcePacks' property to 'resources' in serenity core.