### PR TITLE
fix: export scoreboard class

### DIFF
--- a/packages/core/src/world/index.ts
+++ b/packages/core/src/world/index.ts
@@ -6,3 +6,4 @@ export * from "./generator";
 export * from "./worker";
 export * from "./schedule";
 export * from "./structure";
+export * from "./scoreboard"


### PR DESCRIPTION
Fix scoreboard classes and types not getting exported by the package.