### PR TITLE
Fix soft enum validation.

### DIFF
--- a/packages/core/src/commands/execution-state.ts
+++ b/packages/core/src/commands/execution-state.ts
@@ -98,88 +98,83 @@ class CommandExecutionState {
       Record<string, unknown>
     >;
 
-    // Iterate through the overloads and extract the arguments.
+    // Iterate through the overloads and find a match.
     for (const [overload, callback] of this.command.registry.overloads) {
-      // Create a new context object with the origin.
-      const context = { origin: this.origin } as CommandContext<
-        Record<string, Enum>
-      >;
+      try {
+        // Create a new context object with the origin.
+        const context = { origin: this.origin } as CommandContext<
+          Record<string, Enum>
+        >;
 
-      // Create a new state object with the split array.
-      const state = new CommandArgumentPointer(this, this.split);
+        // Create a new state object with the split array.
+        const state = new CommandArgumentPointer(this, this.split);
 
-      // Iterate through the overload keys and extract the arguments.
-      for (const key in overload) {
-        // Get the value of the key
-        const value = overload[key];
+        // Iterate through the overload keys and extract the arguments.
+        for (const key in overload) {
+          const value = overload[key];
 
-        // Check if the value is null or undefined, if it is then we will continue to the next overload
-        if (!value) continue;
+          // If value is null or undefined, i quit.
+          if (!value) continue;
 
-        // Check if the value is an array, if it is then we will check if the argument is required.
-        if (Array.isArray(value)) {
-          // Get the enum and optional flag from the value.
-          const [type, optional] = value;
+          // Check for array.
+          if (Array.isArray(value)) {
+            // Get the enum and optional flag.
+            const [type, optional] = value;
 
-          // Check if the argument is optional and if there are any arguments left.
-          if (!optional && state.offset >= state.arguments.length) {
-            throw new TypeError(`Argument ${key} is required.`);
+            // Check if the argument is optional and if there are any arguments left.
+            if (!optional && state.offset >= state.arguments.length) {
+              throw new TypeError(`Argument ${key} is required.`);
+            }
+
+            // Extract the argument from the split array.
+            const value_ = type.extract(state as CommandArgumentPointer);
+
+            // Declare if the value is optional.
+            if (value_) value_.optional = optional;
+
+            context[key] = value_ ?? type.default;
+          } else {
+            // Extract the argument from the split array.
+            const value_ = value.extract(state as CommandArgumentPointer);
+
+            // Declare that the enum value is not optional.
+            if (value_) value_.optional = false;
+
+            context[key] = value_ ?? value.default;
           }
-
-          // Extract the argument from the split array.
-          // We will pass the execution state to the extract method.
-          // This allows customs enums to extract the argument in various ways.
-          const value_ = type.extract(state as CommandArgumentPointer);
-
-          // Declare if the value is optional.
-          if (value_) value_.optional = optional;
-
-          // Add the value to the context object.
-          context[key] = value_ ?? type.default;
-        } else {
-          // Extract the argument from the split array.
-          // We will pass the execution state to the extract method.
-          // This allows customs enums to extract the argument in various ways.
-          const value_ = value.extract(state as CommandArgumentPointer);
-
-          // Declare that the enum value is not optional.
-          if (value_) value_.optional = false;
-
-          // Add the value to the context object.
-          context[key] = value_ ?? value.default;
         }
-      }
 
-      // Add the context object to the global context object.
-      Object.assign(globalContext, context);
+        // Add the context object to the global context object.
+        Object.assign(globalContext, context);
 
-      // Check if there are any arguments left in the split array.
-      // If there are, we will continue to the next overload.
-      if (state.offset < state.arguments.length) continue;
+        // Check if there are any arguments left in the split array.
+        // If there are, we will continue to the next overload.
+        if (state.offset < state.arguments.length) continue;
 
-      // Check that the length of the context object is the same as the overload object.
-      // We need to add 1 to compensate for the origin property.
-      if (Object.keys(context).length !== Object.keys(overload).length + 1)
-        continue;
-
-      // Iterate through the context object and try to validate the arguments.
-      for (const [_, value] of Object.entries(context)) {
-        // Check if the value is an instance of Enum.
-        if (!(value instanceof Enum)) continue;
-
-        // Get the result from the value.
-        const result = value.result;
-
-        // Check if the value is optional and if it is not valid.
-        if (value.optional && (result === null || result === undefined))
+        // Check that the length of the context object is the same as the overload object.
+        if (Object.keys(context).length !== Object.keys(overload).length + 1)
           continue;
 
-        // Validate the value.
-        value.validate(true);
-      }
+        // Iterate through the context object and try to validate.
+        for (const [_, value] of Object.entries(context)) {
+          if (!(value instanceof Enum)) continue;
 
-      // Get the response from the callback.
-      return (callback(context) ?? {}) as CommandResponse;
+          const result = value.result;
+
+          // Check if the value is optional and if it is not valid.
+          if (value.optional && (result === null || result === undefined))
+            continue;
+
+          // Validate the value.
+          value.validate(true);
+        }
+
+        // Overload is a match.
+        return (callback(context) ?? {}) as CommandResponse;
+      } catch {
+        // If validation error, continue to the next match.
+        continue;
+      }
     }
 
     // Call the global callback with the global context object.


### PR DESCRIPTION
Currently, soft enum validation was entirely broken. In some cases, you could enter any string value and it would validate it. In others, it would match a completely incorrect overload.

This fix will correctly validate overloads server-side, since we currently can't rely on client-side validation.

**This is not an alternative to real enum support.** Client will still not be able to differentiate between two enum overloads due to both using the string symbol, which renders overload feedback incorrect when typing a command using multiple enums. See my [issue](https://github.com/SerenityJS/serenity/issues/182) for more information.