### PR TITLE
Temporary fix for player data loss outside of default dimension.

### DIFF
--- a/packages/core/src/handlers/disconnect.ts
+++ b/packages/core/src/handlers/disconnect.ts
@@ -22,8 +22,12 @@ class DisconnectHandler extends NetworkHandler {
     // Despawn the player
     player.despawn({ disconnected: true, hasDied: false });
 
-    // Save the player's data
+    // Save the player's data in their current world.
     player.world.provider.writePlayer(player.getLevelStorage());
+
+    // Save the player's data in the default world.
+    const defaultWorld = this.serenity.getWorld()
+    defaultWorld.provider.writePlayer(player.getLevelStorage());
 
     // Nullify the player's permissions
     player.permissions.player = null;

--- a/packages/core/src/handlers/disconnect.ts
+++ b/packages/core/src/handlers/disconnect.ts
@@ -22,12 +22,15 @@ class DisconnectHandler extends NetworkHandler {
     // Despawn the player
     player.despawn({ disconnected: true, hasDied: false });
 
-    // Save the player's data in their current world.
-    player.world.provider.writePlayer(player.getLevelStorage());
-
-    // Save the player's data in the default world.
+    // Teleport the player to the default dimension, where they will login at.
     const defaultWorld = this.serenity.getWorld()
-    defaultWorld.provider.writePlayer(player.getLevelStorage());
+
+    // Set their player position so they spawn at the default world spawn.
+    const storage = player.getLevelStorage()
+    storage.setPosition(defaultWorld.getDimension().spawnPosition)
+
+    // Save the player's data to the default dimension.
+    defaultWorld.provider.writePlayer(storage);
 
     // Nullify the player's permissions
     player.permissions.player = null;


### PR DESCRIPTION
### Understanding the Issue:
Currently, when a player disconnects, their data is saved to the provider of the world they are currently in. However, when they login, their data is read from the default provider.

This already paints a pretty clear picture of the issue. If you log off in another dimension, your data is overwritten by whatever last data was saved for you in the default dimension.

### Why this is a bad fix:
By writing to the data to the default world, any data that doesn't really make sense in the new context (such as the player's position) makes it kind of a janky transition when the player logs in. That's a no bueno.

I have yet to come up with an alternative that fixes this problem well, but this is at least better behavior that we have now, so I'm opening this PR for suggestions and improvements.