### PR TITLE
Fixing `Logger.error()` not accepting color codes.

### DIFF
--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -85,13 +85,14 @@ class Logger {
    * @param arguments_ - The arguments to log.
    */
   public error(...arguments_: Array<unknown>): void {
+    const colorized = this.colorize(...arguments_);
     const format =
       `${LoggerColors.DarkGray + "<"}${LoggerColors.Reset + moment().format("MM-DD-YYYY HH:mm:ss")}${LoggerColors.DarkGray + ">"} ${
         LoggerColors.DarkGray + "["
       }${this.color + this.name + LoggerColors.DarkGray + "]"} ${LoggerColors.DarkGray + "["}${LoggerColors.DarkRed + "Error"}${LoggerColors.DarkGray + "]"}` +
       LoggerColors.Reset;
 
-    console.log(format, ...arguments_);
+    console.log(format, ...colorized);
   }
 
   /**


### PR DESCRIPTION
I know this might be a design choice, but it's been annoying me for weeks, so I thought it was worth at least proposing.