### PR TITLE
Fix goofy container.AddItem logic

### DIFF
--- a/packages/core/src/container.ts
+++ b/packages/core/src/container.ts
@@ -170,7 +170,7 @@ class Container {
         // Create a full stack item for the empty slot
         const newItem = new ItemStack(item.type, {
           ...item,
-          stackSize: item.stackSize
+          stackSize: item.maxStackSize
         });
 
         // Add the new Item and decrease it


### PR DESCRIPTION
## How did no one notice this sooner, lol
Currently, when you try to add an item to a container over the max stack size (such as using `/give @s diamond 192`), for each full stack amount (in this case, 3 stacks), it gives you a stack with the entire amount, and then decrements.

In my example, I'd end up with 1 stack of 192 diamonds, 1 stack of 128 diamonds, and 1 stack of diamonds... which gets super janky, super quick. I'm amazed I was the first person to encounter this issue.