### PR TITLE
Fix logger argument handling for non-string types

### DIFF
--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -148,9 +148,9 @@ class Logger {
 
   public colorize(...arguments_: Array<unknown>): Array<unknown> {
     const colorized = arguments_.map((argument) => {
-      if (typeof argument === "string") {
+      if (typeof argument === "string")
         return formatMinecraftColorCode(argument as string);
-      }
+      else return argument;
     });
 
     return colorized;


### PR DESCRIPTION
Ensures non-string arguments are returned as-is in the logger.