### PR TITLE
Parity vanilla random tick default probability

### DIFF
--- a/packages/core/src/trait.ts
+++ b/packages/core/src/trait.ts
@@ -31,7 +31,7 @@ class Trait {
   /**
    * The chance of this trait being randomly ticked each tick.
    */
-  private readonly randomTickProbability: [number, number] = [0, 1];
+  private readonly randomTickProbability: [number, number] = [1, 4096];
 
   /**
    * Creates a new instance of the trait.


### PR DESCRIPTION
The chance for a block to random tick each tick is roughly 16^3, 1 in 4096, which is how many blocks there are in a subchunk.