### PR TITLE
Fixed two double chest bugs.

### DIFF
--- a/packages/core/src/block/traits/chest.ts
+++ b/packages/core/src/block/traits/chest.ts
@@ -82,6 +82,9 @@ class BlockChestTrait extends BlockInventoryTrait {
     // If there is no source, return
     if (!source || source === this.block) return;
 
+    // Check that the blocks are adjacent.
+    if (this.block.position.y !== source.position.y) return;
+
     if (source.hasTrait(BlockChestTrait) && !this.isPaired()) {
       // Get the chest trait from the source block
       const trait = source.getTrait(BlockChestTrait);
@@ -180,6 +183,11 @@ class BlockChestTrait extends BlockInventoryTrait {
 
   public onInteract({ cancel, origin }: BlockInteractionOptions): void {
     if (cancel || !origin) return;
+
+    if (this.isPaired() && this.getIsPairParent() && this.container.size !== 54) {
+      // Update the container size
+      this.container.size = 54;
+    }
 
     // Check if the chest is paired and this chest is the child
     if (this.isPaired() && !this.getIsPairParent()) {


### PR DESCRIPTION
- Fix 1: Sometimes, when a chest is placed on top of another chest, it tries (and fails) to link the chests, glitching both blocks. I've added a check to ensure the chests are 'adjacent', and placed at the same height to be able to link.
- Fix 2: The container size was incorrect when a paired parent chest is loaded, this ensures the container size is correct when an attempt is made to open it.